### PR TITLE
Switching RENDERING_SETUPS made easier

### DIFF
--- a/src/formula2image.py
+++ b/src/formula2image.py
@@ -111,7 +111,10 @@ def formula_to_image(formula):
             return None
         
         # Turn .pdf to .png
-        code = call((rend_setup[1] % (full_path, full_path)).split(" "), 
+        # Handles variable number of places to insert path.
+        # i.e. "%s.tex" vs "%s.pdf %s.png"
+        full_path_strings = rend_setup[1].count("%")*(full_path,)
+        code = call((rend_setup[1] % full_path_strings).split(" "),
                     stdout=DEVNULL, stderr=DEVNULL)
         
         #Remove files
@@ -140,7 +143,10 @@ def main(formula_list):
     print("Turning formulas into images...")
     pool = Pool(THREADS)
     names = list(pool.imap(formula_to_image, formulas))
-    
+    # Running a thread pool masks debug output. Uncomment command below to run
+    # formulas over images sequentially to see debug errors more clearly
+    # names = [formula_to_image(formula) for formula in formulas]
+
     zipped = list(zip(formulas, names))
     
     new_dataset_lines = []


### PR DESCRIPTION
Summary:
In `formula2image.py`
- `formula_to_image` handles different `RENDERING_SETUPS` supporting an
  easy comment in/out interface at the top of the file, instead of also
  needing to manually change string formatting code inside the function.
- Added a sequential alternative to processing each formula instead of
  thread pools, which can be helpful for people interesting in debugging
  / editing the `formula_to_image` function.
